### PR TITLE
Add `lean` option to reversePopulate

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The options object should contain the following properties...
 - select (object / string) - restrict which fields are returned for your 'related models', see [Query#select](http://mongoosejs.com/docs/api.html#query_Query-select)
 - populate (object / string) - populate your 'related models' with their related models, see [Query#populate](http://mongoosejs.com/docs/api.html#query_Query-populate)
 - sort (object / string) - sort your 'related models', see [Query#sort](http://mongoosejs.com/docs/api.html#query_Query-sort)
+- lean (boolean) - if set to true, the 'related models' will be returned as plain JavaScript objects instead of Mongoose documents. This improves performance and reduces memory usage for large datasets. Note that the modelArray documents themselves are not affected by this option - only the populated related documents become lean. Default is false.
 
 ## Why is this needed?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongoose-promise-reverse-populate",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongoose-promise-reverse-populate",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "mongoose": "^7.6.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongoose-promise-reverse-populate",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongoose-promise-reverse-populate",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "mongoose": "^7.6.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-promise-reverse-populate",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "This module allows you to 'populate' a mongoose model where the relationship ids are stored on another mongoose model that is related to this model",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,6 @@ function populateResult<TopLevelDocument, NestedDocument>(
       match[storeWhere] = [];
     }
 
-    // Debug log
-    // console.log("Before push, result type:", (result as any).constructor?.name);
     // @ts-expect-error TypeScript doesn't like dynamic property access
     match[storeWhere].push(result);
     // console.log("After push, stored type:", (match[storeWhere][0] as any).constructor?.name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ function buildQuery<
   if (options.sort) {
     query.sort(options.sort);
   }
-  if (options.lean) {
+  if (options.lean === true) {
     query.lean();
   }
   return query;
@@ -86,8 +86,11 @@ function populateResult<TopLevelDocument, NestedDocument>(
       match[storeWhere] = [];
     }
 
+    // Debug log
+    // console.log("Before push, result type:", (result as any).constructor?.name);
     // @ts-expect-error TypeScript doesn't like dynamic property access
     match[storeWhere].push(result);
+    // console.log("After push, stored type:", (match[storeWhere][0] as any).constructor?.name);
   } else {
     // @ts-expect-error TypeScript doesn't like dynamic property access
     match[storeWhere] = result;
@@ -106,7 +109,7 @@ function createPopulateResult<TopLevelDocument, NestedDocument>(
 
 /**
  * Options for reverse populating Mongoose documents.
- * 
+ *
  * @template TopLevelDocument - The type of documents in the modelArray
  * @template NestedDocument - The type of documents being populated
  * @template StoreWhere - The property name where populated documents will be stored
@@ -120,25 +123,25 @@ export interface ReversePopulateOptions<
 > {
   /** Array of documents to populate with related documents */
   modelArray: TopLevelDocument[];
-  
+
   /** Property name where the populated documents will be stored */
   storeWhere: StoreWhere;
-  
+
   /** If true, stores populated documents as array; if false, as single value */
   arrayPop: ArrayPop;
-  
+
   /** Mongoose model to query for related documents */
   mongooseModel: Model<NestedDocument>;
-  
+
   /** Field in the related documents that contains the reference ID */
   idField: keyof NestedDocument;
-  
+
   /** Optional MongoDB query filters for the related documents */
   filters?: FilterQuery<NestedDocument>;
-  
+
   /** Optional sort criteria for the related documents */
   sort?: string;
-  
+
   /** Optional populate configuration for nested relationships */
   populate?:
     | {
@@ -150,11 +153,11 @@ export interface ReversePopulateOptions<
         };
       }[]
     | string[];
-  
+
   /** Optional field selection for the related documents */
   select?: string;
-  
-  /** 
+
+  /**
    * If true, returns related documents as plain JavaScript objects instead of Mongoose documents.
    * This improves performance and reduces memory usage. Default: false.
    */
@@ -171,18 +174,18 @@ const REQUIRED_FIELDS = [
 
 /**
  * Populates documents with related documents where the reference is stored on the related model.
- * 
+ *
  * This function solves the "reverse populate" problem in Mongoose, where you need to populate
  * a model with documents that reference it, but the reference is stored on the other model.
- * 
+ *
  * @template TopLevelDocument - The type of documents to populate
  * @template NestedDocument - The type of related documents
  * @template StoreWhere - The property name where populated documents will be stored
  * @template ArrayPop - Whether to store as array (true) or single value (false)
- * 
+ *
  * @param options - Configuration options for the reverse populate operation
  * @returns Promise resolving to the populated documents
- * 
+ *
  * @example
  * ```typescript
  * const authors = await Author.find();
@@ -241,6 +244,10 @@ export async function reversePopulate<
 
   // Do the query
   const documents = await query.exec();
+
+  // Debug: Check document type
+  // console.log("Document type from query:", documents[0]?.constructor?.name);
+  // console.log("Lean option:", options.lean);
 
   // Map over results (models to be populated)
   documents.forEach((document) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,6 @@ function populateResult<TopLevelDocument, NestedDocument>(
 
     // @ts-expect-error TypeScript doesn't like dynamic property access
     match[storeWhere].push(result);
-    // console.log("After push, stored type:", (match[storeWhere][0] as any).constructor?.name);
   } else {
     // @ts-expect-error TypeScript doesn't like dynamic property access
     match[storeWhere] = result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,9 @@ function buildQuery<
   if (options.sort) {
     query.sort(options.sort);
   }
+  if (options.lean) {
+    query.lean();
+  }
   return query;
 }
 
@@ -101,19 +104,42 @@ function createPopulateResult<TopLevelDocument, NestedDocument>(
   };
 }
 
+/**
+ * Options for reverse populating Mongoose documents.
+ * 
+ * @template TopLevelDocument - The type of documents in the modelArray
+ * @template NestedDocument - The type of documents being populated
+ * @template StoreWhere - The property name where populated documents will be stored
+ * @template ArrayPop - Whether to store as array (true) or single value (false)
+ */
 export interface ReversePopulateOptions<
   TopLevelDocument,
   NestedDocument,
   StoreWhere extends string,
   ArrayPop extends boolean,
 > {
+  /** Array of documents to populate with related documents */
   modelArray: TopLevelDocument[];
+  
+  /** Property name where the populated documents will be stored */
   storeWhere: StoreWhere;
+  
+  /** If true, stores populated documents as array; if false, as single value */
   arrayPop: ArrayPop;
+  
+  /** Mongoose model to query for related documents */
   mongooseModel: Model<NestedDocument>;
+  
+  /** Field in the related documents that contains the reference ID */
   idField: keyof NestedDocument;
+  
+  /** Optional MongoDB query filters for the related documents */
   filters?: FilterQuery<NestedDocument>;
+  
+  /** Optional sort criteria for the related documents */
   sort?: string;
+  
+  /** Optional populate configuration for nested relationships */
   populate?:
     | {
         path: string;
@@ -124,7 +150,15 @@ export interface ReversePopulateOptions<
         };
       }[]
     | string[];
+  
+  /** Optional field selection for the related documents */
   select?: string;
+  
+  /** 
+   * If true, returns related documents as plain JavaScript objects instead of Mongoose documents.
+   * This improves performance and reduces memory usage. Default: false.
+   */
+  lean?: boolean;
 }
 
 const REQUIRED_FIELDS = [
@@ -135,6 +169,35 @@ const REQUIRED_FIELDS = [
   "idField",
 ] as const;
 
+/**
+ * Populates documents with related documents where the reference is stored on the related model.
+ * 
+ * This function solves the "reverse populate" problem in Mongoose, where you need to populate
+ * a model with documents that reference it, but the reference is stored on the other model.
+ * 
+ * @template TopLevelDocument - The type of documents to populate
+ * @template NestedDocument - The type of related documents
+ * @template StoreWhere - The property name where populated documents will be stored
+ * @template ArrayPop - Whether to store as array (true) or single value (false)
+ * 
+ * @param options - Configuration options for the reverse populate operation
+ * @returns Promise resolving to the populated documents
+ * 
+ * @example
+ * ```typescript
+ * const authors = await Author.find();
+ * const options = {
+ *   modelArray: authors,
+ *   storeWhere: "posts",
+ *   arrayPop: true,
+ *   mongooseModel: Post,
+ *   idField: "author",
+ *   lean: true  // Optional: for better performance
+ * };
+ * const authorsWithPosts = await reversePopulate(options);
+ * // Each author now has a .posts property with their posts
+ * ```
+ */
 export async function reversePopulate<
   TopLevelDocument,
   NestedDocument,

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,10 +245,6 @@ export async function reversePopulate<
   // Do the query
   const documents = await query.exec();
 
-  // Debug: Check document type
-  // console.log("Document type from query:", documents[0]?.constructor?.name);
-  // console.log("Lean option:", options.lean);
-
   // Map over results (models to be populated)
   documents.forEach((document) => {
     // Check if the ID field is an array

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -198,6 +198,12 @@ describe("reverse populate", () => {
       authResult.forEach((author) => {
         idsMatch(author.posts, posts);
         assert.equal(author.posts.length, 5);
+
+        // Verify default behavior returns Mongoose documents with methods
+        // @ts-expect-error PostData interface doesn't include Mongoose methods
+        assert.equal(typeof author.posts[0].save, "function");
+        // @ts-expect-error PostData interface doesn't include Mongoose methods
+        assert.equal(typeof author.posts[0].populate, "function");
       });
     });
 
@@ -296,7 +302,6 @@ describe("reverse populate", () => {
       });
     });
 
-    // test that lean option returns plain JavaScript objects for related documents
     it("should return lean documents when lean option is true", async () => {
       const opts = {
         modelArray: authors,
@@ -327,6 +332,100 @@ describe("reverse populate", () => {
         // @ts-expect-error These methods don't exist on the PostData interface but would on Mongoose documents
         assert.equal(typeof post.populate, "undefined");
       });
+    });
+
+    it("should return Mongoose documents when lean option is false", async () => {
+      const opts = {
+        modelArray: authors,
+        storeWhere: "posts" as const,
+        arrayPop: true as const,
+        mongooseModel: Post,
+        idField: "author" as const,
+        lean: false,
+      };
+      const authResult = await reversePopulate(opts);
+      assert.equal(authResult.length, 1);
+      idsMatch(authResult, authors);
+
+      const author = authResult[0];
+      assert.equal(author.posts.length, 5);
+
+      // Verify that posts are Mongoose documents with methods
+      author.posts.forEach((post) => {
+        // Mongoose documents should have these methods
+        // @ts-expect-error PostData interface doesn't include Mongoose methods
+        assert.equal(typeof post.save, "function");
+        // @ts-expect-error PostData interface doesn't include Mongoose methods
+        assert.equal(typeof post.populate, "function");
+        // @ts-expect-error PostData interface doesn't include Mongoose methods
+        assert.equal(typeof post.toObject, "function");
+        // @ts-expect-error PostData interface doesn't include Mongoose methods
+        assert.equal(typeof post.toJSON, "function");
+        // Should not be a plain Object
+        assert.notEqual(post.constructor.name, "Object");
+        // Verify the post still has the expected properties
+        assert.notEqual(typeof post.title, "undefined");
+        assert.notEqual(typeof post.author, "undefined");
+        assert.notEqual(typeof post.content, "undefined");
+      });
+    });
+
+    // test comparison between lean true and false
+    it("should behave differently with lean true vs false", async () => {
+      // Get fresh author instances for each test to avoid interference
+      const authorsForLean = await Author.find();
+      const authorsForNonLean = await Author.find();
+
+      const optsLean = {
+        modelArray: authorsForLean,
+        storeWhere: "posts" as const,
+        arrayPop: true as const,
+        mongooseModel: Post,
+        idField: "author" as const,
+        lean: true,
+      };
+
+      const optsNonLean = {
+        modelArray: authorsForNonLean,
+        storeWhere: "posts" as const,
+        arrayPop: true as const,
+        mongooseModel: Post,
+        idField: "author" as const,
+        lean: false,
+      };
+
+      const leanResult = await reversePopulate(optsLean);
+      const nonLeanResult = await reversePopulate(optsNonLean);
+
+      const leanPost = leanResult[0].posts[0];
+      const nonLeanPost = nonLeanResult[0].posts[0];
+
+      // Data should be the same
+      assert.equal(leanPost.title, nonLeanPost.title);
+      assert.equal(leanPost.content, nonLeanPost.content);
+
+      // For lean documents
+      assert.equal(leanPost.constructor.name, "Object");
+      // @ts-expect-error PostData interface doesn't include Mongoose methods
+      assert.equal(typeof leanPost.save, "undefined");
+
+      // For non-lean documents - they should have Mongoose methods
+      // The specific constructor name might vary, but it should have methods
+      // @ts-expect-error PostData interface doesn't include Mongoose methods
+      const hasSaveMethod = typeof nonLeanPost.save === "function";
+      // @ts-expect-error PostData interface doesn't include Mongoose methods
+      const hasPopulateMethod = typeof nonLeanPost.populate === "function";
+
+      assert.equal(
+        hasSaveMethod,
+        true,
+        "Non-lean document should have save method",
+      );
+      assert.equal(
+        hasPopulateMethod,
+        true,
+        "Non-lean document should have populate method",
+      );
     });
   });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -295,6 +295,39 @@ describe("reverse populate", () => {
         idsMatch(post.categories, categories);
       });
     });
+
+    // test that lean option returns plain JavaScript objects for related documents
+    it("should return lean documents when lean option is true", async () => {
+      const opts = {
+        modelArray: authors,
+        storeWhere: "posts" as const,
+        arrayPop: true as const,
+        mongooseModel: Post,
+        idField: "author" as const,
+        lean: true,
+      };
+      const authResult = await reversePopulate(opts);
+      assert.equal(authResult.length, 1);
+      idsMatch(authResult, authors);
+
+      const author = authResult[0];
+      assert.equal(author.posts.length, 5);
+
+      // Verify that posts are plain objects (lean documents)
+      author.posts.forEach((post) => {
+        // Lean documents should be plain objects without Mongoose document methods
+        assert.equal(post.constructor.name, "Object");
+        // Verify the post still has the expected properties
+        assert.notEqual(typeof post.title, "undefined");
+        assert.notEqual(typeof post.author, "undefined");
+        assert.notEqual(typeof post.content, "undefined");
+        // Check that it doesn't have Mongoose document methods
+        // @ts-expect-error These methods don't exist on the PostData interface but would on Mongoose documents
+        assert.equal(typeof post.save, "undefined");
+        // @ts-expect-error These methods don't exist on the PostData interface but would on Mongoose documents
+        assert.equal(typeof post.populate, "undefined");
+      });
+    });
   });
 
   describe("singular results", () => {


### PR DESCRIPTION
# Summary

Adds a new optional `lean` parameter to the `reversePopulate` function that allows fetching related documents as plain JavaScript objects instead of full Mongoose documents, improving performance and reducing memory usage for large datasets.

## Changes

- ✨ Added `lean?: boolean` option to `ReversePopulateOptions` interface
- 🔧 Modified `buildQuery()` to conditionally apply `.lean()` when option is enabled
- 📝 Added comprehensive JSDoc documentation for the interface and main function
- ✅ Added test coverage verifying lean documents are returned without Mongoose methods
- 📚 Updated README with documentation for the new option

## Why this change?

When reverse populating large datasets, Mongoose documents carry significant overhead with their methods and internal state. The lean option allows users to opt into receiving plain JavaScript objects for better performance when they don't need Mongoose document functionality on the populated data.

## Backward Compatibility

The change is fully backward compatible - the lean option defaults to `false`, maintaining existing behavior for all current users.

## Example Usage

```javascript
const authorsWithPosts = await reversePopulate({
  modelArray: authors,
  storeWhere: "posts",
  arrayPop: true,
  mongooseModel: Post,
  idField: "author",
  lean: true  // New option for better performance
});
```